### PR TITLE
Add required builtin tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ uuid
     Only valid for string types, it will validate the value matches
     the well-known universally unique identifier defined in
     RFC 4122. (Usage: uuid)
+
+required
+    This validates the value is required, that is a pointer is
+    nil. (Usage: required)
 ```
 
 Custom validators

--- a/extensions.go
+++ b/extensions.go
@@ -16,6 +16,30 @@
 
 package validator
 
+import "reflect"
+
+// required validates the value is not nil for a field, that is, a
+// pointer or an interface, any other case is a valid one as zero
+// value from Go spec
+func required(v interface{}, param string) error {
+	st := reflect.ValueOf(v)
+	var valid bool
+	switch st.Kind() {
+	case reflect.Ptr, reflect.Interface:
+		valid = !st.IsNil()
+	case reflect.Invalid:
+		valid = false
+	case reflect.String, reflect.Slice, reflect.Map, reflect.Array, reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr, reflect.Float32, reflect.Float64, reflect.Bool, reflect.Struct:
+		valid = true
+	default:
+		return ErrUnsupported
+	}
+	if valid {
+		return nil
+	}
+	return ErrRequired
+}
+
 // uuid validates if a string represents a valid UUID (RFC 4122)
 func uuid(v interface{}, param string) error {
 	uuidRE := "(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"

--- a/validator.go
+++ b/validator.go
@@ -71,6 +71,9 @@ var (
 	// ErrInvalid is the error returned when variable is invalid
 	// (normally a nil pointer)
 	ErrInvalid = TextErr{errors.New("invalid value")}
+	// ErrRequired is the error returned when variable is nil and
+	// required tag was specified
+	ErrRequired = TextErr{errors.New("required value")}
 )
 
 // ErrorMap is a map which contains all errors from validating a struct.
@@ -122,12 +125,13 @@ func NewValidator() *Validator {
 	return &Validator{
 		tagName: "validate",
 		validationFuncs: map[string]ValidationFunc{
-			"nonzero": nonzero,
-			"len":     length,
-			"min":     min,
-			"max":     max,
-			"regexp":  regex,
-			"uuid":    uuid,
+			"nonzero":  nonzero,
+			"len":      length,
+			"min":      min,
+			"max":      max,
+			"regexp":   regex,
+			"uuid":     uuid,
+			"required": required,
 		},
 	}
 }


### PR DESCRIPTION
This allows us to know whether a pointer is nil or not. See tests for more information.
```go
type Struct struct {
    field *float64 `validate:"required"`
}
```