### PR TITLE
speed up validation by caching info for types

### DIFF
--- a/extensions_test.go
+++ b/extensions_test.go
@@ -136,6 +136,7 @@ func (es *ExtensionSuite) TestLatitudeNOK(c *C) {
 	for _, l := range cases {
 		err := walidator.Valid(l, "latitude")
 		c.Assert(err, NotNil)
+		c.Assert(err, FitsTypeOf, walidator.ErrorArray{})
 		errs, ok := err.(walidator.ErrorArray)
 		c.Assert(ok, Equals, true)
 		c.Assert(errs, HasLen, 1)


### PR DESCRIPTION
This also opens the way for speeding up the individual validators,
which can now return a specialized validator function for a given
type.

I've added one benchmark to get some idea of the speedup
(the validated type is similar to one in some production code).

        name        old time/op  new time/op  delta
        Validate-4  10.6µs ± 2%   0.9µs ± 3%  -91.81%  (p=0.008 n=5+5)
