### PR TITLE
Fix README.md paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ Installation
 Just use go get.
 
 ```bash
-go get github.com/heetch/walidator
+go get github.com/heetch/walidator/v4
 ```
 
 And then just import the package into your own code.
 
 ```go
 import (
-	"github.com/heetch/walidator
+	"github.com/heetch/walidator/v4
 )
 ```
 
@@ -35,7 +35,7 @@ type NewUserRequest struct {
 }
 
 nur := NewUserRequest{Username: "something", Age: 20}
-if err := validator.Validate(nur); err != nil {
+if err := walidator.Validate(nur); err != nil {
 	// values not valid, deal with errors here
 }
 ```


### PR DESCRIPTION
The current commands written in the README.md files lead to fetching the old version of `walidator`

```
go get github.com/heetch/walidator
go: finding github.com/heetch/walidator v3.2.0+incompatible
go: downloading github.com/heetch/walidator v3.2.0+incompatible
go: extracting github.com/heetch/walidator v3.2.0+incompatible
```

With the new commands we can retrieve the correct version:

```
go get github.com/heetch/walidator/v4
go: finding github.com/heetch/walidator/v4 v4.0.0
go: downloading github.com/heetch/walidator/v4 v4.0.0
go: extracting github.com/heetch/walidator/v4 v4.0.0
``` 